### PR TITLE
fix: remove SQLAlchemy from project classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ classifiers = [
     "Framework :: FastAPI",
     "Framework :: Pydantic :: 2",
     "Framework :: Pydantic",
-    "Framework :: SQLAlchemy :: 2",
-    "Framework :: SQLAlchemy",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",


### PR DESCRIPTION
# Problem

* `'Framework :: SQLAlchemy'` is not a valid classifier.

# Solution

* Remove it from project classifiers.